### PR TITLE
Use up-to-date, specific, non-RC version of alpine: `1.9.3-alpine3.7`

### DIFF
--- a/bifrost-docker/Dockerfile
+++ b/bifrost-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine as builder
+FROM golang:1.9.3-alpine3.7 as builder
 
 ADD apk-build /apk-build
 RUN chmod +x /apk-build


### PR DESCRIPTION
There are some instances where `:alpine` was breaking the build:

```
[INFO]  --> Exporting gopkg.in/tylerb/graceful.v1
[INFO]  Replacing existing vendor dependencies
github.com/stellar/go/vendor/github.com/btcsuite/btcd/btcjson
vendor/github.com/btcsuite/btcd/btcjson/cmdinfo.go:10:2: import /usr/local/go/pkg/linux_amd64/strings.a: reading input: EOF
```

This pull request rules out compile issues (since it only specifies the builder base image) that may arise from having different base images.