### PR TITLE
User specified bifrost cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,18 @@ Defaults to testnet.
 
 Creates a folder 'stellar' in your home folder.  Everything is stored there, delete it to reset.
 
-You'll need to edit the docker-compose.yml files to change environment vars to match your setup:
-MASTER_PUBLIC_KEY, BIFROST_STELLAR_ISSUER_PUBLIC_KEY, BIFROST_STELLAR_SIGNER_SECRET_KEY, TOKEN_ASSET_CODE
-
 Edit docker-compose.yml for mainnet
 
 Pull requests welcome!
+
+### Setup
+
+Look at `docker-compose.yml` as a guide.
+
+#### Config
+
+- *From environment variables*. You can specify the environment variables (see `docker-compose.yml`) and allow `entry.sh` to generate the config file for you.
+- *Supply your own `bifrost.cfg`*. If `entry.sh` sees a file in `/opt/bifrist/bifrost.cfg`, it will use that and ignore any environment variables. This is useful when you need a more customized cfg, and attaching a volume (like a configmap or secret in Kubernetes) is easier.
 
 ### Donations
 If you like this code, a [`donation`](https://stellarkit.io/#/donate) would be appreciated.

--- a/bifrost-docker/Dockerfile
+++ b/bifrost-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine as builder
+FROM golang:1.9.3-alpine3.7 as builder
 
 ADD apk-build /apk-build
 RUN chmod +x /apk-build

--- a/bifrost-docker/Dockerfile
+++ b/bifrost-docker/Dockerfile
@@ -6,11 +6,12 @@ RUN /apk-build
 
 # deploy bifrost binary
 RUN mkdir -p /go/src/github.com/stellar/ \
-    && git clone --depth 1 --branch master https://github.com/stellar/go.git /go/src/github.com/stellar/go \
-    && cd /go/src/github.com/stellar/go \
-    && curl https://glide.sh/get | sh \
-    && glide install \
-    && go install github.com/stellar/go/services/bifrost
+    && git clone --depth 1 --branch master https://github.com/stellar/go.git /go/src/github.com/stellar/go
+
+ENV BIFROST_VERSION=v0.0.1
+ENV BIFROST_URL=https://github.com/stellar/go/releases/download/bifrost-$BIFROST_VERSION/bifrost-linux-amd64
+RUN wget $BIFROST_URL
+RUN chmod +x bifrost-linux-amd64 && mv bifrost-linux-amd64 /go/bin/bifrost
 
     # deploy db init script
     ADD initbifrost /go/src/github.com/stellar/initbifrost

--- a/bifrost-docker/Dockerfile
+++ b/bifrost-docker/Dockerfile
@@ -13,10 +13,10 @@ ENV BIFROST_URL=https://github.com/stellar/go/releases/download/bifrost-$BIFROST
 RUN wget $BIFROST_URL
 RUN chmod +x bifrost-linux-amd64 && mv bifrost-linux-amd64 /go/bin/bifrost
 
-    # deploy db init script
-    ADD initbifrost /go/src/github.com/stellar/initbifrost
-    RUN go get github.com/lib/pq \
-        && go install github.com/stellar/initbifrost
+# deploy db init script
+ADD initbifrost /go/src/github.com/stellar/initbifrost
+RUN go get github.com/lib/pq \
+    && go install github.com/stellar/initbifrost
 
 
 # -----------------------

--- a/bifrost-docker/entry.sh
+++ b/bifrost-docker/entry.sh
@@ -3,7 +3,13 @@
 set -e
 
 function main() {
-  build-config /configs/config.toml > /opt/bifrost/bifrost.cfg
+  BIFROST_CFG=/opt/bifrost/bifrost.cfg
+  if [ -f $BIFROST_CFG ]; then
+    echo "$BIFROST_CFG exists; skipping generation"
+  else
+    echo "$BIFROST_CFG does not exist; generating from environment variables"
+    build-config /configs/config.toml > /opt/bifrost/bifrost.cfg
+  fi
 
   build-config /configs/pgpass-config > /root/.pgpass
   chmod 600 /root/.pgpass


### PR DESCRIPTION
Useful for more complex configurations, like when Ethereum is not accepted. On Kubernetes, mounting a secret or configmap right in the expected location should suffice.

Requires:

- [ ] https://github.com/StellarKit/stellar-bifrost/pull/2